### PR TITLE
Fix accessibility issues on the page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -167,7 +167,6 @@ p, h1, h2, h3, h4, h5, h6 {
     font-size: 1.2rem;
     font-weight: bold;
     font-style: italic;
-    text-align: justify;
 }
 
 #content-image {
@@ -186,7 +185,6 @@ p, h1, h2, h3, h4, h5, h6 {
     color: var(--font-color);
     letter-spacing: 0.2ch;
     cursor: pointer;
-    text-decoration: none;
 }
 
 #community-section h1::after {
@@ -249,7 +247,6 @@ p, h1, h2, h3, h4, h5, h6 {
 }
 
 .card-sub, .card-detail {
-    font-size: 1.3rem;
     padding: 5px 0;
     font-weight: bold;
     overflow: hidden;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -23,11 +23,11 @@ const createParticipantes = (listOfParticipants) => {
   listOfParticipants.forEach(async (participant) => {
     const cardHTML = `
       <h2 class="card-title">${await getRandomEmoji()} ${participant.name}</h2>
-      <p class="card-sub margin-yt-sm">📅 Started: ${participant.course_start}</p>
-      <p class="card-sub margin-yb-sm custom-underline">🎓 Stage:  ${participant.course_stage}</p>
-      <p class="card-detail">Loves: ${participant.favorite_language} 😍 </p>
-      <p class="card-detail custom-underline">Learning: ${participant.currently_learning} 📚 </p>
-      <a class="participant-link" href="community/${participant.name}" data-content="View Work ➡">View Work ➡</a>
+      <h3 class="card-sub margin-yt-sm">📅 Started: ${participant.course_start}</h3>
+      <h3 class="card-sub margin-yb-sm custom-underline">🎓 Stage:  ${participant.course_stage}</h3>
+      <h3 class="card-detail">Loves: ${participant.favorite_language} 😍 </h3>
+      <h3 class="card-detail custom-underline">Learning: ${participant.currently_learning} 📚 </h3>
+      <a class="participant-link" href="community/${participant.name}" data-content= "">${participant.name}'s Work ➡</a>
       `;
 
     const card = createElement("div", "card");

--- a/index.html
+++ b/index.html
@@ -20,9 +20,8 @@
                 have specified tasks that emulate a
                 Ticket in a live environment.
                 <br>
-                Help us by sharing the project to Twitter:
-                <a href="https://ctt.ac/qZN6i" target="_blank" rel="noopener noreferrer" class="twitter-link">👉 click
-                    here!</a>
+                Help us by sharing the project to 👉
+                <a href="https://ctt.ac/qZN6i" target="_blank" rel="noopener noreferrer" class="twitter-link">Twitter!</a>
             </p>
         </div>
 
@@ -50,7 +49,7 @@
         </div>
 
         <div id="additional-info">
-            <p>Meet the team:</p>
+            <h3>Meet the team:</h3>
             <ul id="team-list">
                 <li>
                     <a href="https://github.com/auxfuse" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
# Hackathon Git Labs Project PR 🎉🎉

## PR contains:
- Fix all the structural components and order of header tags 
- Footer heading fix
- Fix link tags that showed "View more" to be more specific as they can be interpreted as malicious links by screenreaders
- Also removed click here on sharing to Twitter link and added style to make the link visible: Rule of thumb to follow is that all links should make sense even if the preceding text is taken away

## Hacktoberfest 2022:
- [x] Does this PR follow the `intermediate.md` guide and submitted as part of Hacktoberfest 2022?

## Breaking changes
- None

## Screenshots
- At first, these are the alerts we started with for the page.
<img width="1369" alt="Screenshot 2022-10-03 at 1 26 32 PM" src="https://user-images.githubusercontent.com/19901599/193565278-b5375f43-3e19-4635-a00e-6e28bd6c25dd.png">

- There are no more accessibility issues as per the tool  I am using to test, the manual tests I did also checked out
<img width="369" alt="Screenshot 2022-10-03 at 2 05 17 PM" src="https://user-images.githubusercontent.com/19901599/193565492-e6a565d5-6bb2-4c24-9547-f2cad8c14bb2.png">

