### PR TITLE
CSS minor edit for card title fix

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -279,7 +279,6 @@ h6 {
 }
 
 .card-title {
-    width: inherit;
     margin-bottom: 1rem;
     padding: 1rem;
     text-align: center;


### PR DESCRIPTION
Minor change to fix the overflowing of the blue background on the cards' tittle (card-title class).

Before:

![image](https://user-images.githubusercontent.com/47335142/195191615-e0befa4f-c7ff-4c89-b2d4-0173aefd7484.png)


After:

![image](https://user-images.githubusercontent.com/47335142/195191692-d0c04299-9e05-46df-8d1e-d5e32d55637f.png)

Happy coding, and Hacktoberfest 2022 😉