### PR TITLE
Re-adding removed workflow file to directory

### DIFF
--- a/.github/workflows/json-file-check.yml
+++ b/.github/workflows/json-file-check.yml
@@ -1,0 +1,17 @@
+name: JSON check
+
+on:
+  push:
+    paths:
+      - '**.json'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: json-syntax-check
+        uses: limitusus/json-syntax-check@v1
+        with:
+          pattern: "\\.json$"


### PR DESCRIPTION
# Hackathon Git Labs Project PR 🎉🎉

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## PR contains:
- Workflow was removed in most recent PR
- github directory now added to `gitignore` so this should not happen again

## Hacktoberfest 2022:
- [x] Does this PR follow the `intermediate.md` guide and submitted as part of Hacktoberfest 2022?

_Please note, we cannot accept `basic.md` PR submissions for Hacktoberfest, it must be a custom HTML or CSS creation following the `intermediate.md` guide._

## Breaking changes
- Resolves removed workflow file

## Screenshots
- None