### PR TITLE
remove the width inherit from .card-title to stop it from overflowing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -279,7 +279,7 @@ h6 {
 }
 
 .card-title {
-    width: inherit;
+    /* width: inherit; */
     margin-bottom: 1rem;
     padding: 1rem;
     text-align: center;


### PR DESCRIPTION
# Hackathon Git Labs Project PR 🎉🎉


## PR contains:
I noticed the perticipant cards title was overflowing it's container. The title had a width of inherit so removing this stopped the title overflowing the card. I've only commented it out for the moment.

## Breaking changes
None

## Screenshots
<img width="325" alt="Screenshot 2022-10-14 at 09 59 39" src="https://user-images.githubusercontent.com/63146014/195807465-5be7a7bd-cbf3-46b8-835e-3a062a3d65bd.png">
<img width="322" alt="Screenshot 2022-10-14 at 09 59 26" src="https://user-images.githubusercontent.com/63146014/195807482-b9f48b36-e166-40d1-8858-a84c647151c3.png">

