### PR TITLE
small addition to check for currentPage and redirect if not detected

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -77,6 +77,10 @@ function pagePagination(participants, currentPage, perPage) {
   paginationEl.appendChild(paginationNextLi);
   paginationNextLi.append(paginationNextButton);
 
+  if(!currentPage) {
+    window.location.href = '?page=1';
+  }
+
   if (currentPage === totalPages) {
     paginationNextLi.style.display = "none";
   };


### PR DESCRIPTION
# Hackathon Git Labs Project PR 🎉🎉

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## PR contains:
- no default page set during pagination, so a small detection method set on `currentPage` and if nothing detected it defaults to page 1 on appending to the current url
```js
if(!currentPage) {
    window.location.href = '?page=1';
}
```

## Hacktoberfest 2022:
- [X] Does this PR follow the `intermediate.md` guide and submitted as part of Hacktoberfest 2022?


## Breaking changes
- resolves broken render of community section (will eventually be superseded in further PR from @manni8436 with styling of pagination and clamp function to the Pagination Function)

## Screenshots
- before fix:
![image](https://user-images.githubusercontent.com/48055438/197545052-efd05814-27e5-43c8-a861-3fc1e68c5c9c.png)

- after fix home url now redirects with query string of page set to 1:
![19e4116b9cef778bc3ae73d905f97693](https://user-images.githubusercontent.com/48055438/197545545-c407ca31-6abf-48ba-a11b-6f7315cb8807.gif)
