### PR TITLE
💄 Remove card-title width setting

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -357,7 +357,6 @@ h6 {
 }
 
 .card-title {
-    width: inherit;
     margin-bottom: 1rem;
     padding: 1rem;
     text-align: center;


### PR DESCRIPTION
# Hackathon Git Labs Project PR 🎉🎉

## PR contains:

- Update CSS file to stop the card title from spilling out

## Screenshots

**Before**

![Screenshot 2022-10-26 at 12 07 18](https://user-images.githubusercontent.com/64651250/198010911-f551ae8a-9a08-4831-a34e-9f0e6ebf248d.png)

**After**

![Screenshot 2022-10-26 at 12 07 00](https://user-images.githubusercontent.com/64651250/198010932-c66efe3f-86a3-4eed-a0b7-74f59e72153b.png)
