### PR TITLE
Pagination tweaks

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -713,7 +713,7 @@ select,
     font-weight: bolder;
     opacity: 0;
     position: fixed;
-    top: 50%;
+    top: 20%;
     transition: all 0.2s ease-in-out;
     padding-inline-start: 20px;
 }
@@ -724,14 +724,12 @@ select,
 
 .pagination-active {
     background-color: #94EBF1;
-    font-size: x-large;
 }
 
-.next-button:hover,
-.prev-button:hover,
-.pagination-numbers:hover {
-    background-color: #94EBF1;
-    width: fit-content;
+.next-button,
+.prev-button,
+.pagination-numbers {
+    font-size: 1.5rem;
 }
 
 /* Media Queries */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -228,6 +228,10 @@ h6 {
     cursor: pointer;
 }
 
+#community-section {
+    display: relative;
+}
+
 #showcases-section h1::after,
 #community-section h1::after {
     content: '';
@@ -707,6 +711,11 @@ select,
 #pagination {
     list-style: none;
     font-weight: bolder;
+    opacity: 0;
+    position: fixed;
+    top: 50%;
+    transition: all 0.2s ease-in-out;
+    padding-inline-start: 20px;
 }
 
 #pagination a {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,7 +7,8 @@
     --font-color: #202020;
     --font-color-lt: #f3f3f3;
     --primary-color: #94ebf1;
-    --secondary-color: #072c30;
+    --primary-color-lt: #c9e7e9;
+    --secondary-color: #1e3d41;
     --secondary-color-lt: #1f5d64;
     --tertiary-color: #94b0b3;
     --tertiary-color-dk: #434f50;
@@ -248,7 +249,7 @@ h6 {
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-    margin-bottom: 7rem;
+    margin: 0 3.5rem 7rem;
 }
 
 #showcases {
@@ -710,20 +711,29 @@ select,
 
 #pagination {
     list-style: none;
-    font-weight: bolder;
     opacity: 0;
     position: fixed;
     top: 20%;
     transition: all 0.2s ease-in-out;
-    padding-inline-start: 20px;
+    padding-inline-start: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    row-gap: 1rem;
+    z-index: 1;
 }
 
 #pagination a {
     text-decoration: none;
+    color: var(--secondary-color-lt);
 }
 
-.pagination-active {
-    background-color: #94EBF1;
+#pagination a.pagination-active {
+    padding: 8px;
+    color: var(--secondary-color);
+    font-weight: bolder;
+    border-radius: 0px 8px 8px 0;
+    border-left: 1px solid var(--secondary-color-lt);
 }
 
 .next-button,
@@ -752,6 +762,10 @@ select,
 
     #content-column p {
         word-spacing: 5px;
+    }
+
+    #pagination {
+        padding-inline-start: 2.5rem;
     }
 
     /* Footer */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,126 +1,171 @@
-import { genIndexes, shuffle, clamp } from './modules/utilities.js';
-import { createParticipantesCards, createSkeletonLoaders } from './modules/cards.js';
+import { genIndexes, shuffle, clamp } from "./modules/utilities.js";
+import {
+    createParticipantesCards,
+    createSkeletonLoaders,
+} from "./modules/cards.js";
 
-
-document.getElementById('showcases-slideshow')
-  .addEventListener('slide-changed', e => {
-    const titleEl = document.getElementById('showcases-slide-title');
-    titleEl.innerHTML = '';
-    titleEl.append(e.detail.querySelector('.slide-title > .card-title').cloneNode(true));
-  });
-
+document
+    .getElementById("showcases-slideshow")
+    .addEventListener("slide-changed", (e) => {
+        const titleEl = document.getElementById("showcases-slide-title");
+        titleEl.innerHTML = "";
+        titleEl.append(
+            e.detail.querySelector(".slide-title > .card-title").cloneNode(true)
+        );
+    });
 
 (() => {
+    const communityElements = {
+        // Maximum number of cards to append for this section
+        count: 10,
+        // The element to append cards to
+        container: document.querySelector("#community"),
+        // The HTML template to use as a base for each card
+        template: document.querySelector("#community-section > .item-template"),
+    };
+    const showcaseElements = {
+        count: 5,
+        container: document.querySelector("#showcases-slideshow"),
+        template: document.querySelector("#showcases > .item-template"),
+    };
 
-  const communityElements = {
-    // Maximum number of cards to append for this section
-    count: 10,
-    // The element to append cards to
-    container: document.querySelector("#community"),
-    // The HTML template to use as a base for each card
-    template: document.querySelector("#community-section > .item-template")
-  };
-  const showcaseElements = {
-    count: 5,
-    container: document.querySelector("#showcases-slideshow"),
-    template: document.querySelector("#showcases > .item-template")
-  };
-
-  // Create Loaders for community section cards
-  if (communityElements.container && communityElements.template) {
-    createSkeletonLoaders(communityElements);
-  }
-
-  // Preload data
-  Promise.all([
-
-    // Participant records
-    fetch("assets/data/community.json")
-      .then(response => response.json()),
-    // Emoji list
-    fetch("assets/data/emojis.json")
-      .then((response) => response.json()),
-
-  ]).then((values) => {
-    // When all data has loaded:
-    const [participants, emojis] = values;
-    const perPage = 6;
-    let currentPage = Number(new URLSearchParams(window.location.search).get("page"));
-
-    let pageParticipants = pagePagination(participants, currentPage, perPage);
-
-    if (showcaseElements.container && showcaseElements.template) {
-      const indexes = shuffle(genIndexes(participants.length));
-      createParticipantesCards(participants, emojis, showcaseElements, indexes, true);
-    }
-
+    // Create Loaders for community section cards
     if (communityElements.container && communityElements.template) {
-      // Alter count to show all cards
-      communityElements.count = participants.length;
-      communityElements.container.innerHTML = "";
-      createParticipantesCards(participants, emojis, communityElements, pageParticipants);
+        createSkeletonLoaders(communityElements);
     }
-  });
+
+    // Preload data
+    Promise.all([
+        // Participant records
+        fetch("assets/data/community.json").then((response) => response.json()),
+        // Emoji list
+        fetch("assets/data/emojis.json").then((response) => response.json()),
+    ]).then((values) => {
+        // When all data has loaded:
+        const [participants, emojis] = values;
+        const perPage = 6;
+        let currentPage = Number(
+            new URLSearchParams(window.location.search).get("page")
+        );
+
+        let pageParticipants = pagePagination(
+            participants,
+            currentPage,
+            perPage
+        );
+
+        if (showcaseElements.container && showcaseElements.template) {
+            const indexes = shuffle(genIndexes(participants.length));
+            createParticipantesCards(
+                participants,
+                emojis,
+                showcaseElements,
+                indexes,
+                true
+            );
+        }
+
+        if (communityElements.container && communityElements.template) {
+            // Alter count to show all cards
+            communityElements.count = participants.length;
+            communityElements.container.innerHTML = "";
+            createParticipantesCards(
+                participants,
+                emojis,
+                communityElements,
+                pageParticipants
+            );
+        }
+    });
 })();
 
 // pagination
+const paginationParent = document.getElementById("community-section");
+const paginationEl = document.getElementById("pagination");
 
 function pagePagination(participants, currentPage, perPage) {
-  const paginationEl = document.getElementById("pagination");
-  const totalPages = Math.ceil(participants.length / perPage);
+    const totalPages = Math.ceil(participants.length / perPage);
 
-  currentPage = clamp(currentPage, 1, totalPages)
+    currentPage = clamp(currentPage, 1, totalPages);
 
-  const paginationNextLi = document.createElement('li')
-  const paginationNextButton = document.createElement('a');
-  
-  paginationNextButton.textContent = "Next";
-  paginationNextButton.href = `?page=${currentPage + 1}`;
-  paginationEl.appendChild(paginationNextLi);
-  paginationNextLi.append(paginationNextButton);
+    const paginationNextLi = document.createElement("li");
+    const paginationNextButton = document.createElement("a");
 
-  paginationNextLi.classList.add('next-button');
+    paginationNextButton.textContent = "Next";
+    paginationNextButton.href = `?page=${currentPage + 1}`;
+    paginationEl.appendChild(paginationNextLi);
+    paginationNextLi.append(paginationNextButton);
 
-  if (currentPage === totalPages) {
-    paginationNextLi.style.display = "none";
-  };
+    paginationNextLi.classList.add("next-button");
 
-  for (let i = 0; i < totalPages; i++) {
-    const paginationLi = document.createElement('li');
-    const paginationLink = document.createElement('a');
-    
-    paginationLink.textContent = i + 1;
-    paginationLink.href = `?page=${i+1}`;
-    paginationEl.appendChild(paginationLi);
-    paginationLi.append(paginationLink);
+    if (currentPage === totalPages) {
+        paginationNextLi.style.display = "none";
+    }
 
-    if (currentPage == i + 1) {
-      paginationLink.classList.add("pagination-active");
-    };
-    paginationLi.classList.add('pagination-numbers');
-  }
+    for (let i = 0; i < totalPages; i++) {
+        const paginationLi = document.createElement("li");
+        const paginationLink = document.createElement("a");
 
+        paginationLink.textContent = i + 1;
+        paginationLink.href = `?page=${i + 1}`;
+        paginationEl.appendChild(paginationLi);
+        paginationLi.append(paginationLink);
 
-  const paginationPrevLi = document.createElement('li')
-  const paginationPrevButton = document.createElement('a');
-  
-  paginationPrevButton.textContent = "Previous";
-  paginationPrevButton.href = `?page=${currentPage - 1}`;
-  paginationEl.appendChild(paginationPrevLi);
-  paginationPrevLi.append(paginationPrevButton);
+        if (currentPage == i + 1) {
+            paginationLink.classList.add("pagination-active");
+        }
+        paginationLi.classList.add("pagination-numbers");
+    }
 
-  paginationPrevLi.classList.add('prev-button');
+    const paginationPrevLi = document.createElement("li");
+    const paginationPrevButton = document.createElement("a");
 
-  if (currentPage === 1) {
-    paginationPrevLi.style.display = "none";
-  };
-  
-  let firstParticipantIndex = currentPage * perPage - perPage;
-  let lastParticipantIndex = currentPage * perPage -1;
-  
-  if (lastParticipantIndex >= participants.length) {
-    lastParticipantIndex = participants.length -1;
-  };
-  
-return genIndexes(lastParticipantIndex+1, firstParticipantIndex);
-};
+    paginationPrevButton.textContent = "Previous";
+    paginationPrevButton.href = `?page=${currentPage - 1}`;
+    paginationEl.appendChild(paginationPrevLi);
+    paginationPrevLi.append(paginationPrevButton);
+
+    paginationPrevLi.classList.add("prev-button");
+
+    if (currentPage === 1) {
+        paginationPrevLi.style.display = "none";
+    }
+
+    let firstParticipantIndex = currentPage * perPage - perPage;
+    let lastParticipantIndex = currentPage * perPage - 1;
+
+    if (lastParticipantIndex >= participants.length) {
+        lastParticipantIndex = participants.length - 1;
+    }
+
+    return genIndexes(lastParticipantIndex + 1, firstParticipantIndex);
+}
+
+// pagination observer
+
+let isMobile = window.matchMedia("only screen and (max-width: 480px)").matches;
+
+let tHold;
+if(isMobile) {
+    tHold = 0.2;
+} else {
+    tHold = 0.4;
+}
+
+const options = {
+    root: null,
+    threshold: tHold
+}
+
+const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      // console.log(entry);
+      if(entry['isIntersecting'] === true) {
+          paginationEl.style.opacity = 1;
+      } else {
+          paginationEl.style.opacity = 0;
+      }
+    });
+}, options);
+
+observer.observe(paginationParent);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -91,8 +91,8 @@ function pagePagination(participants, currentPage, perPage) {
     const paginationNextLi = document.createElement("li");
     const paginationNextButton = document.createElement("a");
 
-    paginationNextButton.textContent = "Next";
-    paginationNextButton.href = `?page=${currentPage + 1}`;
+    paginationNextButton.textContent = "➡️";
+    paginationNextButton.href = `?page=${currentPage + 1}#community-section`;
     paginationEl.appendChild(paginationNextLi);
     paginationNextLi.append(paginationNextButton);
 
@@ -107,7 +107,7 @@ function pagePagination(participants, currentPage, perPage) {
         const paginationLink = document.createElement("a");
 
         paginationLink.textContent = i + 1;
-        paginationLink.href = `?page=${i + 1}`;
+        paginationLink.href = `?page=${i + 1}#community-section`;
         paginationEl.appendChild(paginationLi);
         paginationLi.append(paginationLink);
 
@@ -120,8 +120,8 @@ function pagePagination(participants, currentPage, perPage) {
     const paginationPrevLi = document.createElement("li");
     const paginationPrevButton = document.createElement("a");
 
-    paginationPrevButton.textContent = "Previous";
-    paginationPrevButton.href = `?page=${currentPage - 1}`;
+    paginationPrevButton.textContent = "⬅️";
+    paginationPrevButton.href = `?page=${currentPage - 1}#community-section`;
     paginationEl.appendChild(paginationPrevLi);
     paginationPrevLi.append(paginationPrevButton);
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -89,18 +89,17 @@ function pagePagination(participants, currentPage, perPage) {
 
     currentPage = clamp(currentPage, 1, totalPages);
 
-    const paginationNextLi = document.createElement("li");
-    const paginationNextButton = document.createElement("a");
+    const paginationPrevLi = document.createElement("li");
+    const paginationPrevButton = document.createElement("a");
+    paginationPrevButton.textContent = "⬅️";
+    paginationPrevButton.href = `?page=${currentPage - 1}#community-section`;
+    paginationEl.appendChild(paginationPrevLi);
+    paginationPrevLi.append(paginationPrevButton);
+    
+    paginationPrevLi.classList.add("prev-button");
 
-    paginationNextButton.textContent = "➡️";
-    paginationNextButton.href = `?page=${currentPage + 1}#community-section`;
-    paginationEl.appendChild(paginationNextLi);
-    paginationNextLi.append(paginationNextButton);
-
-    paginationNextLi.classList.add("next-button");
-
-    if (currentPage === totalPages) {
-        paginationNextLi.style.display = "none";
+    if (currentPage === 1) {
+        paginationPrevLi.style.display = "none";
     }
 
     for (let i = 0; i < totalPages; i++) {
@@ -123,18 +122,17 @@ function pagePagination(participants, currentPage, perPage) {
         paginationLi.classList.add("pagination-numbers");
     }
 
-    const paginationPrevLi = document.createElement("li");
-    const paginationPrevButton = document.createElement("a");
+    const paginationNextLi = document.createElement("li");
+    const paginationNextButton = document.createElement("a");
+    paginationNextButton.textContent = "➡️";
+    paginationNextButton.href = `?page=${currentPage + 1}#community-section`;
+    paginationEl.appendChild(paginationNextLi);
+    paginationNextLi.append(paginationNextButton);
 
-    paginationPrevButton.textContent = "⬅️";
-    paginationPrevButton.href = `?page=${currentPage - 1}#community-section`;
-    paginationEl.appendChild(paginationPrevLi);
-    paginationPrevLi.append(paginationPrevButton);
+    paginationNextLi.classList.add("next-button");
 
-    paginationPrevLi.classList.add("prev-button");
-
-    if (currentPage === 1) {
-        paginationPrevLi.style.display = "none";
+    if (currentPage === totalPages) {
+        paginationNextLi.style.display = "none";
     }
 
     let firstParticipantIndex = currentPage * perPage - perPage;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -116,7 +116,7 @@ function pagePagination(participants, currentPage, perPage) {
             paginationLink.classList.add("pagination-active");
             if(paginationLink.classList.contains("pagination-active")) {
                 if(!isMobile) {
-                    paginationLink.innerHTML += "🐱‍🏍";
+                    paginationLink.innerHTML = `🐱‍🏍${i + 1}`;
                 }
             }
         }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -82,6 +82,7 @@ document
 // pagination
 const paginationParent = document.getElementById("community-section");
 const paginationEl = document.getElementById("pagination");
+let isMobile = window.matchMedia("only screen and (max-width: 480px)").matches;
 
 function pagePagination(participants, currentPage, perPage) {
     const totalPages = Math.ceil(participants.length / perPage);
@@ -113,6 +114,11 @@ function pagePagination(participants, currentPage, perPage) {
 
         if (currentPage == i + 1) {
             paginationLink.classList.add("pagination-active");
+            if(paginationLink.classList.contains("pagination-active")) {
+                if(!isMobile) {
+                    paginationLink.innerHTML += "🐱‍🏍";
+                }
+            }
         }
         paginationLi.classList.add("pagination-numbers");
     }
@@ -143,13 +149,11 @@ function pagePagination(participants, currentPage, perPage) {
 
 // pagination observer
 
-let isMobile = window.matchMedia("only screen and (max-width: 480px)").matches;
-
 let tHold;
 if(isMobile) {
-    tHold = 0.2;
+    tHold = 0.25;
 } else {
-    tHold = 0.4;
+    tHold = 0.6;
 }
 
 const options = {

--- a/index.html
+++ b/index.html
@@ -77,33 +77,33 @@
         </div>
         <!-- Community card template -->
         <template class="item-template">
-        <div class="card">
-            <h2 class="card-title">
-                <span data-field="random_emoji"></span>
-                <span data-field="name">_</span>
-            </h2>
-            <h3 class="card-sub margin-yt-sm">
-                📅 Started: <span data-field="course_start"></span>
-            </h3>
-            <h3 class="card-sub margin-yb-sm custom-underline">
-                🎓 Stage: <span data-field="course_stage"></span>
-            </h3>
-            <h3 class="card-detail">
-                Loves: <span data-field="favorite_language"></span> 😍 
-            </h3>
-            <h3 class="card-detail custom-underline">
-                Learning: <span data-field="currently_learning"></span> 📚 
-            </h3>
-            <a class="participant-link" href="" data-content="View Work ➡" data-field="link">
-                View Work ➡
-            </a>
-        </div>
-    </template>
+            <div class="card">
+                <h2 class="card-title">
+                    <span data-field="random_emoji"></span>
+                    <span data-field="name">_</span>
+                </h2>
+                <h3 class="card-sub margin-yt-sm">
+                    📅 Started: <span data-field="course_start"></span>
+                </h3>
+                <h3 class="card-sub margin-yb-sm custom-underline">
+                    🎓 Stage: <span data-field="course_stage"></span>
+                </h3>
+                <h3 class="card-detail">
+                    Loves: <span data-field="favorite_language"></span> 😍 
+                </h3>
+                <h3 class="card-detail custom-underline">
+                    Learning: <span data-field="currently_learning"></span> 📚 
+                </h3>
+                <a class="participant-link" href="" data-content="View Work ➡" data-field="link">
+                    View Work ➡
+                </a>
+            </div>
+        </template>
+
+        <ul id="pagination"></ul>
     </section>
 
-    <ul id="pagination"></ul>
-
-    <footer>
+    <footer id="footer">
         <div id="repo-go">
             <p>
                 Want to contribute to this project?


### PR DESCRIPTION
# Hackathon Git Labs Project PR 🎉🎉

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## PR contains:
- This PR styles and adds interactivity functionality to the pagination element created previously by @manni8436 👏 
- Intersection Observation API utilised via JS to detect when community sections is entering & leaving the viewport root element to show/hide the pagination component.
    - on mobile, this detection threshold is set to 0.25, which translates to once the community section has 25% of it's element inside the viewport height, the pagination will appear, and once it reaches the last 25% the pagination will disappear
    - on desktop, this threshold is set to 0.6, or 60% of the community section needing to be visible before the pagination appears. This is intentionally set, as this covers the first row of the community cards, and is visibly clean against the other elements already visibile on the page. See giphys below.
- this PR also reverse the polarity of the next / previous buttons originally implemented in previous PR. Along with this, the words next/previous were replaced with Emoji arrows
- complete `main.js` refactor and format
- complete `style.css` refactor and format
- `index.html` formatting tweaks to community section card
- further optimisations to cater for each viewport to come in subsequent commits/PRs

## Breaking changes
- None

## Screenshots
- mobile pagination appear/fade:
https://i.gyazo.com/29442980ca8ea013da9306c5e4e5b16a.gif

- tablet/desktop pagination appear/fade:
https://i.gyazo.com/c3963ac70fd3616fc79a6cc9940a8fec.gif